### PR TITLE
dbeaver/pro#9969 Fix high CVE-2026-10050. increase dbeaver-deps-ce

### DIFF
--- a/composite-bundles/jetty.server/pom.xml
+++ b/composite-bundles/jetty.server/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jkiss.bundle</groupId>
     <artifactId>jetty.server</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
     <parent>
         <groupId>com.dbeaver.osgi</groupId>

--- a/composite-bundles/jetty12.websocket/pom.xml
+++ b/composite-bundles/jetty12.websocket/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.jkiss.bundle</groupId>
     <artifactId>jetty12.websocket</artifactId>
-    <version>12.1.7</version>
+    <version>12.1.11</version>
     <packaging>pom</packaging>
     <parent>
         <groupId>com.dbeaver.osgi</groupId>


### PR DESCRIPTION
jetty.server: 1.0.3 -> 1.0.4
jetty12.websocket: 12.1.7 -> 12.1.11