### PR TITLE
Dbeaver/pro#9978 jexl update

### DIFF
--- a/p2/feature/feature.xml
+++ b/p2/feature/feature.xml
@@ -1,4 +1,4 @@
-<feature
+ <feature
         id="com.dbeaver.deps.ce.feature"
         label="DBeaver Community Dependencies"
         version="1.0.0.qualifier"
@@ -11,7 +11,7 @@
     <plugin id="org.antlr.antlr4-runtime" version="0.0.0"/>
     <plugin id="com.github.jsqlparser" version="0.0.0"/>
     <plugin id="org.apache.commons.commons-logging" version="0.0.0" />
-    <plugin id="org.apache.commons.jexl" version="0.0.0" />
+    <plugin id="org.apache.commons.jexl3" version="0.0.0" />
     <plugin id="org.apache.commons.lang3" version="0.0.0" />
     <plugin id="org.apache.ant" version="1.99.1" />
     <plugin id="com.jcraft.jsch" version="0.2.8" />

--- a/p2/feature/feature.xml
+++ b/p2/feature/feature.xml
@@ -1,4 +1,4 @@
- <feature
+<feature
         id="com.dbeaver.deps.ce.feature"
         label="DBeaver Community Dependencies"
         version="1.0.0.qualifier"

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl3</artifactId>
-            <version>3.1</version>
+            <version>3.7</version>
             <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
         </dependency>
         <dependency>

--- a/p2/pom.xml
+++ b/p2/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-jexl3</artifactId>
-            <version>3.7</version>
+            <version>3.7.0</version>
             <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Closes Dbeaver/pro#9978
made a separate bundle because jexl changed it's naming in p2 but not in Maven which requires 2 separate version for Eclipse and for us 